### PR TITLE
add hunyuan_game_craft evaluation

### DIFF
--- a/examples/pipeline_mapping.py
+++ b/examples/pipeline_mapping.py
@@ -6,6 +6,13 @@ def load_matrix_game2_pipeline(model_path, device):
             device=device,
             )
 
+def load_hunyuan_game_craft_pipeline(model_path, device):
+    from sceneflow.pipelines.hunyuan_world.pipeline_hunyuan_game_craft import HunyuanGameCraftPipeline
+    return HunyuanGameCraftPipeline.from_pretrained(
+            synthesis_model_path=model_path,
+            device=device,
+            )
+
 def load_qwen2p5_omni_pipeline(model_path, device):
     from sceneflow.pipelines.qwen.pipeline_qwen2p5_omni import Qwen2p5OmniPipeline
     return Qwen2p5OmniPipeline.from_pretrained(
@@ -18,6 +25,7 @@ def load_qwen2p5_omni_pipeline(model_path, device):
 ## utilize lazy loader to load different tasks pipeline
 video_gen_pipe = {
     "matrix-game2": load_matrix_game2_pipeline,
+    "hunyuan-game-craft": load_hunyuan_game_craft_pipeline,
 }
 
 reasoning_pipe = {

--- a/src/sceneflow/pipelines/hunyuan_world/pipeline_hunyuan_game_craft.py
+++ b/src/sceneflow/pipelines/hunyuan_world/pipeline_hunyuan_game_craft.py
@@ -41,7 +41,7 @@ class HunyuanGameCraftPipeline:
         seed: int = 250160,
         **kwargs,
     ) -> "HunyuanGameCraftPipeline":
-        args = parse_args()
+        args = parse_args(args=[])
         args.cpu_offload = cpu_offload
         args.seed = seed
 

--- a/src/sceneflow/synthesis/visual_generation/hunyuan_world/hunyuan_game_craft/config.py
+++ b/src/sceneflow/synthesis/visual_generation/hunyuan_world/hunyuan_game_craft/config.py
@@ -11,10 +11,10 @@ def as_tuple(x):
     else:
         raise ValueError(f"Unknown type {type(x)}")
 
-def parse_args(namespace=None):
+def parse_args(args=None, namespace=None):
     parser = argparse.ArgumentParser(description="Hunyuan Multimodal training/inference script")
     parser = add_extra_args(parser)
-    args = parser.parse_args(namespace=namespace)
+    args = parser.parse_args(args=args, namespace=namespace)
     args = sanity_check_args(args)
     return args
 


### PR DESCRIPTION
- 主要添加 hunyuan-game-craft 的 pipeline 映射与 lazy loader
- 修复 HunyuanGameCraftPipeline.from_pretrained() 的参数解析冲突：原 pipeline 读取外部 CLI 参数，和 benchmark 参数冲突。修复后不再读取用户命令行参数，只会使用配置默认值和 from_pretrained 里显式赋值的参数