### PR TITLE
[Fix] inconsistent i2v generation in Cosmos-Predict2.5

### DIFF
--- a/src/openworldlib/base_models/diffusion_model/video/wan_2p1/utils/fm_solvers_unipc.py
+++ b/src/openworldlib/base_models/diffusion_model/video/wan_2p1/utils/fm_solvers_unipc.py
@@ -166,6 +166,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
         sigmas: Optional[List[float]] = None,
         mu: Optional[Union[float, None]] = None,
         shift: Optional[Union[float, None]] = None,
+        use_kerras_sigma: bool = False,
     ):
         """
         Sets the discrete timesteps used for the diffusion chain (to be run before inference).
@@ -185,6 +186,17 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
             sigmas = np.linspace(self.sigma_max, self.sigma_min,
                                  num_inference_steps +
                                  1).copy()[:-1]  # pyright: ignore
+        
+        if use_kerras_sigma:
+            # force to use the exact sigma used in edm sampler
+            sigma_max = 200
+            sigma_min = 0.01
+            rho = 7
+            sigmas = np.arange(num_inference_steps + 1) / num_inference_steps
+            min_inv_rho = sigma_min ** (1 / rho)
+            max_inv_rho = sigma_max ** (1 / rho)
+            sigmas = (max_inv_rho + sigmas * (min_inv_rho - max_inv_rho)) ** rho
+            sigmas = sigmas / (1 + sigmas)
 
         if self.config.use_dynamic_shifting:
             sigmas = self.time_shift(mu, 1.0, sigmas)  # pyright: ignore

--- a/src/openworldlib/synthesis/visual_generation/cosmos/cosmos_predict2p5_synthesis.py
+++ b/src/openworldlib/synthesis/visual_generation/cosmos/cosmos_predict2p5_synthesis.py
@@ -67,7 +67,7 @@ class CosmosPredict2p5Synthesis(BaseSynthesis):
         token: Optional[str] = None,
         device: Optional[torch.device] = None,
         weight_dtype: Optional[torch.dtype] = torch.float32,
-    ) -> "Cosmos2p5PredictSynthesis":
+    ) -> "CosmosPredict2p5Synthesis":
         """
         Cosmos-Predict2.5 supports two modes: ['img2world', 'video2world'], currently we only support img2world.
         """
@@ -366,6 +366,7 @@ class CosmosPredict2p5Synthesis(BaseSynthesis):
             num_inference_steps,
             device=device,
             shift=5.0,
+            use_kerras_sigma=True,
         )
         timesteps = self.scheduler.timesteps
 

--- a/test/test_cosmos_predict2p5.py
+++ b/test/test_cosmos_predict2p5.py
@@ -29,7 +29,7 @@ pipeline = CosmosPredict2p5Pipeline.from_pretrained(
     token=token,
     mode="img2world",
     device="cuda",
-    weight_dtype=torch.bfloat16
+    weight_dtype=torch.bfloat16,
 )
 
 # Set default negative prompt
@@ -55,6 +55,7 @@ save_path = "cosmos_predict2p5_demo.mp4"
 output_video = pipeline(
     prompt=prompt,
     image_path=image_path,
+    cond_timestep=0.1,
     output_type='np',  # Optional[str] = 'pt', 'pil', 'np' ...
     num_inference_steps=35,
 )[0]  # shape: (T, H, W, C)

--- a/test_stream/test_cosmos_predict2p5_stream.py
+++ b/test_stream/test_cosmos_predict2p5_stream.py
@@ -28,7 +28,7 @@ pipeline = CosmosPredict2p5Pipeline.from_pretrained(
     token=token,
     mode="img2world",
     device="cuda",
-    weight_dtype=torch.bfloat16
+    weight_dtype=torch.bfloat16,
 )
 
 # Set default negative prompt
@@ -80,8 +80,9 @@ while True:
         prompt=user_prompt,
         images=last_frame_img,
         image_path=image_path,
+        cond_timestep=0.1,
         output_type='pt',  # Optional[str] = 'pt', 'pil', 'np' ...
-        num_inference_steps=1,
+        num_inference_steps=35,
     )
 
     last_frame_img = pipeline.memory_module.select()


### PR DESCRIPTION
## PR 内容：

1. 修复 Cosmos-Predict2.5  I2V 生成的首帧一致性问题
2. 为 Cosmos 添加非线性 Karras sigma 时间步调度

## 测试结果

- 通过运行 `test/test_cosmos_predict2p5.py` 测试确认修复有效性