### PR TITLE
docs: integrate JEPA series papers

### DIFF
--- a/docs/awesome_world_model.md
+++ b/docs/awesome_world_model.md
@@ -349,7 +349,22 @@
 
 #### Joint-Embedding Predictive Architecture (JEPA)
 
+<details>
+<summary><strong> JEPA Family Models </strong></summary>
 
+- **I-JEPA** · [[Paper]](https://arxiv.org/pdf/2301.08243) [[Code]](https://github.com/facebookresearch/ijepa)
+- **MC-JEPA** · [[Paper]](https://arxiv.org/pdf/2307.12698) [[Code]](#)
+- **V-JEPA** · [[Paper]](https://arxiv.org/pdf/2404.08471) [[Code]](https://github.com/facebookresearch/jepa)
+- **Point-JEPA** · [[Paper]](https://arxiv.org/pdf/2404.16432) [[Code]](https://github.com/Ayumu-J-S/Point-JEPA)
+- **3D-JEPA** · [[Paper]](https://arxiv.org/pdf/2409.15803) [[Code]](#)
+- **ACT-JEPA** · [[Paper]](https://arxiv.org/pdf/2501.14622) [[Code]](#)
+- **V-JEPA 2** · [[Paper]](https://arxiv.org/pdf/2506.09985) [[Code]](https://github.com/facebookresearch/vjepa2)
+- **Audio-JEPA** · [[Paper]](https://arxiv.org/pdf/2507.02915) [[Code]](https://github.com/LudovicTuncay/Audio-JEPA)
+- **LeJEPA** · [[Paper]](https://arxiv.org/pdf/2511.08544) [[Code]](https://github.com/galilai-group/lejepa)
+- **Causal-JEPA** · [[Paper]](https://arxiv.org/pdf/2602.11389) [[Code]](https://github.com/galilai-group/cjepa)
+- **LeWorldModel** · [[Paper]](https://arxiv.org/pdf/2603.19312v1) [[Code]](https://github.com/lucas-maes/le-wm)
+- **Think-JEPA** · [[Paper]](https://arxiv.org/pdf/2603.22281) [[Code]](#)
+</details>
 
 ---
 

--- a/docs/awesome_world_model.md
+++ b/docs/awesome_world_model.md
@@ -347,6 +347,10 @@
 - **WorldGrow** · [[Paper]](https://arxiv.org/abs/2510.21682) [[Code]](https://github.com/world-grow/WorldGrow)
 </details>
 
+#### Joint-Embedding Predictive Architecture (JEPA)
+
+
+
 ---
 
 ### World Model - Memory


### PR DESCRIPTION
Hi, I am submitting this PR to integrate the **JEPA (Joint-Embedding Predictive Architecture)** series, may filling a  gap for latent-space predictive world models in this repository.

- Included the full lineage (from I-JEPA to Think-JEPA) under `Simulator and Representation`.

**Some Notes:**
- The paper (*A Path Towards...*) is kept exclusively in the `Positional Paper` section to avoid duplication, as it serves as the theoretical blueprint rather than a specific implementation.
- **V-JEPA 2** is retained in both the `VLA` and the new `JEPA` section to reflect its dual role as an embodied foundation and an architectural of jepa.

btw, I've specifically emphasized LeWorldModel due to its potentially Single-GPU training feasibility.

Best regards!