### PR TITLE
fix(flash_world): 修正 camera_l / camera_r 的 yaw 符号

### DIFF
--- a/src/openworldlib/operators/flash_world_operator.py
+++ b/src/openworldlib/operators/flash_world_operator.py
@@ -121,9 +121,9 @@ def _orientation_in_place_at_t(
     """Camera fixed; orientation interpolated over segment (t in [0, 1])."""
     t = float(np.clip(t, 0.0, 1.0))
     if action == "camera_l":
-        return _rotate_yaw_world(quat_start, -t * _YAW_PER_SEGMENT)
-    if action == "camera_r":
         return _rotate_yaw_world(quat_start, t * _YAW_PER_SEGMENT)
+    if action == "camera_r":
+        return _rotate_yaw_world(quat_start, -t * _YAW_PER_SEGMENT)
     if action == "camera_up":
         return _rotate_pitch_local(quat_start, t * _PITCH_PER_SEGMENT)
     if action == "camera_down":


### PR DESCRIPTION
_orientation_in_place_at_t 里 camera_l / camera_r 的 yaw 符号搞反了： camera_l（pan left）用的是负 yaw，渲出来的视频实际向右转，camera_r 反之。

把两个符号互换，让视频里相机的转向方向和 action 标签一致。

验证：用 sun397 + Qwen-2.5-VL 生成的 10 个 pilot scene 重新渲染， camera_l 现在视觉上向左转，camera_r 向右转。