### PR TITLE
Fix PatchEmbed input size assertions

### DIFF
--- a/src/openworldlib/synthesis/visual_generation/sana/sana_wm/sana_wm_diffusion/model/nets/sana_blocks.py
+++ b/src/openworldlib/synthesis/visual_generation/sana/sana_wm/sana_wm_diffusion/model/nets/sana_blocks.py
@@ -1223,8 +1223,8 @@ class PatchEmbed(nn.Module):
 
     def forward(self, x):
         B, C, H, W = x.shape
-        assert (H == self.img_size[0], f"Input image height ({H}) doesn't match model ({self.img_size[0]}).")
-        assert (W == self.img_size[1], f"Input image width ({W}) doesn't match model ({self.img_size[1]}).")
+        assert H == self.img_size[0], f"Input image height ({H}) doesn't match model ({self.img_size[0]})."
+        assert W == self.img_size[1], f"Input image width ({W}) doesn't match model ({self.img_size[1]})."
         x = self.proj(x)
         if self.flatten:
             x = x.flatten(2).transpose(1, 2)  # BCHW -> BNC


### PR DESCRIPTION
The height and width checks in `PatchEmbed.forward` currently assert a non-empty tuple, so they always pass even when the input shape is wrong.

This changes both statements to use the assertion message as the second `assert` operand. Invalid image dimensions now reach the intended `AssertionError` before convolution.

Validation:
- `python3 -W error::SyntaxWarning -m py_compile src/openworldlib/synthesis/visual_generation/sana/sana_wm/sana_wm_diffusion/model/nets/sana_blocks.py`
- AST check confirming both assertion tests are comparison expressions and retain messages